### PR TITLE
Fixing issue with np.cumsum on Windows

### DIFF
--- a/seq2struct/utils/batched_sequence.py
+++ b/seq2struct/utils/batched_sequence.py
@@ -74,7 +74,7 @@ class PackedSequencePlus:
                 raise ValueError('Lengths are not descending: {}'.format(value))
     
     def __attrs_post_init__(self):
-        self.__dict__['cum_batch_sizes'] = np.cumsum([0] + self.ps.batch_sizes[:-1].tolist())
+        self.__dict__['cum_batch_sizes'] = np.cumsum([0] + self.ps.batch_sizes[:-1].tolist()).astype(np.int_)
 
     def apply(self, fn):
         return attr.evolve(self, ps=torch.nn.utils.rnn.PackedSequence(


### PR DESCRIPTION
np.cumsum on Windows creates an array with type np.intc instead of int32 or int64. So, we explicitly cast it to np.int_, which is the platform-dependent "long" (64-bit on Linux, 32-bit on Windows). This only happens once during setup, so performance shouldn't be a concern.