### PR TITLE
Ignore .jsonl files in data

### DIFF
--- a/data/spider-20190205/.gitignore
+++ b/data/spider-20190205/.gitignore
@@ -1,4 +1,5 @@
 *.json
+*.jsonl
 *.sql
 *.zip
 nl2code/


### PR DESCRIPTION
preprocess creates .jsonl files in data/spider-20190205/nl2code-401…./. Adding to .gitignore so they are ignored.